### PR TITLE
Merge (rebase to rsksmart/faucet), improvements and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Copy example-config.json to config.json and configure with your data.
 - rsk-Faucet.js configuration variables on top of file
 - lib/rsk-helper.js configure urlOfFaucetServer
-- put some SBTCs on the faucet address
+- put some RBTCs on the faucet address
 
 
 ## TODO

--- a/css/index.css
+++ b/css/index.css
@@ -135,6 +135,10 @@ p, label {
   box-sizing: content-box;
 }
 
+p{
+  font-size: 1.5em;
+}
+
 .input::placeholder {
   color: #568475;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     url: faucetUrl + '/balance',
     async: true,
     cache: false,
-		success: (result) => $('#balance').html(result),
+		success: (result) => $('#balance').html(parseFloat(result).toFixed(5)),
 		error: (xhr, status, error) => handleError('Error loading faucet balance.')
 	})
 
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			url: faucetUrl,
 			cache: false,
 			data: { 'rskAddress': addr, 'captcha': captcha },
-			success: (result) => $('#result').html('<b>Successfully sent some SBTCs to that address<b>'),
+			success: (result) => $('#result').html('<b>Successfully sent some RBTCs to that address<b>'),
 			error: (xhr, status, error) => {
 				let message = xhr.responseText === undefined || xhr.responseText === '' || xhr.responseText === null ?
 					error.toString() :

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,6 @@
     <title>rsk testnet faucet</title>
     <link rel="icon" href="img/favicon.ico">
   </head>
-$.getScript(url, successCallback)
   <body>
     <div id="root">
       <div class="app">
@@ -35,7 +34,7 @@ $.getScript(url, successCallback)
         <main class="app-main">
           <div class="faucet">
             <div class="label-container">
-              <p>Faucet balance is <b id="balance">...</b> SBTC.</p>
+              <p>Faucet balance is <b id="balance">...</b> RBTC.</p>
             </div>
             <div class="input-container">
               <input id="address" class="input" placeholder="0xBa56870a3bc9...">

--- a/rsk-faucet.js
+++ b/rsk-faucet.js
@@ -104,7 +104,7 @@ function getWeb3() {
 
   console.log('using web3', rskNode);
   web3 = new Web3();
-  web3.setProvider(new web3.providers.HttpProvider('http://' + rskNode));
+  web3.setProvider(new web3.providers.HttpProvider(rskNode));
 
   return web3;
 }
@@ -147,7 +147,7 @@ function estimateGasPrice(){
   if (block.minimumGasPrice <= 1) {
     return 1;
   } else {
-    return block.minimumGasPrice * 1.0001;
+    return block.minimumGasPrice * 1.01;
   }
 }
 
@@ -197,11 +197,6 @@ app.get('/balance', function (req, res) {
 });
 
 app.post('/', function (req, res) {
-  if (!isValidRSKAddress(req.body.rskAddress, 31)) {
-    console.log('Invalid RSK address format ', req.body.rskAddress);
-    return res.status(400).send('Invalid RSK address format.');
-  }
-
   if (accountAlreadyUsed(req.body.rskAddress)) {
     console.log('Address already used today:', req.body.rskAddress);
     return res.status(400).send('Address already used today.');
@@ -225,7 +220,14 @@ app.post('/', function (req, res) {
     executeTransfer(req.body.rskAddress)
 
     faucetHistory[req.body.rskAddress.toLowerCase()] = {timestamp: new Date().getTime()};
-    res.send('Successfully sent some SBTCs to ' + req.body.rskAddress + '.');
+    if (isValidRSKAddress(req.body.rskAddress, 31)) {
+      res.send('Successfully sent some RBTCs to ' + req.body.rskAddress + '.');
+    } else {
+      console.log(rskUtil.toChecksumAddress(req.body.rskAddress.toLowerCase(), 31));
+      res.send('Successfully sent some RBTCs to ' + req.body.rskAddress + '. </br>' +
+        'Please consider using this address with RSK Testnet checksum: ' + rskUtil.toChecksumAddress(req.body.rskAddress.toLowerCase(), 31));
+    }
+
   } else {
     res.status(400).send('We can not tranfer any amount right now. Try again later.' + req.body.rskAddress + '.');
   }


### PR DESCRIPTION
Hi @ilanolkies!
This PR includes:
- Rebase to **rsksmart/faucet**: there were some changes (related with SBTC/RBTC renaming, remove RSK checksum validation and add +1% when calculating gasprice) that your repo didn't have.
- Consider RSK public-node didn't support `syncing` method and Faucet uses it [here](https://github.com/ilanolkies/faucet/blob/master/rsk-faucet.js#L215), **I didn't remove it**. Also consider removing `http://` prefix when setting web3 provider (**I suggested it on this PR**).

Cheers!